### PR TITLE
Update react-native-vector-icons to 7.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "prop-types": "^15.7.2",
-    "react-native-vector-icons": "^6.6.0",
+    "react-native-vector-icons": "^7.0.0",
     "styled-components": "^5.1.1"
   }
 }


### PR DESCRIPTION
Update to 7.0.0 to resolve issues present in 6.7.0 (Unable to resolve module Toolbar-Android )